### PR TITLE
Add ColorPalette type to encapsulate results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
  - 1.4.2
  - tip
+install: make get-deps
 script: make test
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-test:
-	go test -v -cpu 1,2,4 -race ./...
-
 benchmark:
 	go test -v -cpu 1,2,4 -race -bench . -benchmem ./...
 
-.PHONY: benchmark test
+get-deps:
+	go get -u github.com/golang/lint/golint
+
+test:
+	golint .
+	go vet .
+	go test -v -cpu 1,2,4 -race ./...
+
+.PHONY: benchmark get-deps test

--- a/color_palette.go
+++ b/color_palette.go
@@ -1,0 +1,40 @@
+package palettor
+
+import (
+	"image/color"
+)
+
+// A ColorPalette represents the dominant colors extracted from an image.
+type ColorPalette struct {
+	colorWeights map[color.Color]float64
+	iterations   int
+}
+
+// Colors returns the colors in a color palette.
+func (p *ColorPalette) Colors() []color.Color {
+	colors := make([]color.Color, len(p.colorWeights))
+	i := 0
+	for color := range p.colorWeights {
+		colors[i] = color
+		i++
+	}
+	return colors
+}
+
+// Count returns the number of colors in a color palette.
+func (p *ColorPalette) Count() int {
+	return len(p.colorWeights)
+}
+
+// Iterations returns the number of iterations required to extract the colors
+// of a palette.
+func (p *ColorPalette) Iterations() int {
+	return p.iterations
+}
+
+// Weight returns the weight of a color in a palette as a float in the range
+// [0, 1], or 0 if a given color is not in a palette.
+func (p *ColorPalette) Weight(c color.Color) float64 {
+	weight, _ := p.colorWeights[c]
+	return weight
+}

--- a/kmeans_test.go
+++ b/kmeans_test.go
@@ -60,7 +60,7 @@ func TestDistance(t *testing.T) {
 }
 
 func TestNearest(t *testing.T) {
-	var haystack []color.Color = []color.Color{black, white, red, green, blue}
+	var haystack = []color.Color{black, white, red, green, blue}
 
 	if nearest(black, haystack) != black {
 		t.Fatalf("nearest color to self should be self")
@@ -74,7 +74,7 @@ func TestNearest(t *testing.T) {
 }
 
 func TestFindCentroid(t *testing.T) {
-	var cluster []color.Color = []color.Color{black, white, red, mostlyRed}
+	var cluster = []color.Color{black, white, red, mostlyRed}
 	centroid := findCentroid(cluster)
 	found := false
 	for _, c := range cluster {
@@ -88,43 +88,41 @@ func TestFindCentroid(t *testing.T) {
 }
 
 func TestCluster(t *testing.T) {
-	var observations []color.Color = []color.Color{black, white, red}
+	var colors = []color.Color{black, white, red}
 
 	k := 4
-	clusters, iterations, err := Cluster(k, 100, observations)
-	if clusters != nil || iterations != 0 || err == nil {
-		t.Fatalf("too few observations should result in an error")
+	palette, err := ClusterColors(k, 100, colors)
+	if err == nil {
+		t.Fatalf("too few colors should result in an error")
 	}
 
 	k = 3
-	clusters, _, _ = Cluster(k, 100, observations)
-	if len(clusters) != k {
-		t.Fatalf("expected %d clusters, got %d; %v", k, len(clusters), clusters)
+	palette, _ = ClusterColors(k, 100, colors)
+	if palette.Count() != k {
+		t.Fatalf("expected %d clusters, got %d", k, palette.Count())
 	}
 
 	k = 2
-	observations = []color.Color{black, white}
-	clusters, _, _ = Cluster(k, 100, observations)
-	weight, _ := clusters[black]
-	if weight != 0.5 {
+	colors = []color.Color{black, white}
+	palette, _ = ClusterColors(k, 100, colors)
+	if palette.Weight(black) != 0.5 {
 		t.Fatalf("expected weight of black cluster to be 0.5")
 	}
-	weight, _ = clusters[white]
-	if weight != 0.5 {
+	if palette.Weight(white) != 0.5 {
 		t.Fatalf("expected weight of white cluster to be 0.5")
 	}
 }
 
-func BenchmarkCluster(b *testing.B) {
+func BenchmarkClusterColors(b *testing.B) {
 	// We generally expect an input image to have been thumbnailed down to a
 	// manageable size (e.g. 200x200 pixels) before its colors are extracted.
-	observationCount := 200 * 200
-	observations := make([]color.Color, observationCount)
-	for i := 0; i < observationCount; i++ {
-		observations[i] = randomColor()
+	colorCount := 200 * 200
+	colors := make([]color.Color, colorCount)
+	for i := 0; i < colorCount; i++ {
+		colors[i] = randomColor()
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		Cluster(4, 100, observations)
+		ClusterColors(4, 100, colors)
 	}
 }

--- a/palettor.go
+++ b/palettor.go
@@ -1,3 +1,5 @@
+// Package palettor provides a way to extract the color palette from an image
+// using k-means clustering.
 package palettor
 
 import (
@@ -5,9 +7,10 @@ import (
 	"image/color"
 )
 
-// DominantColors uses k-means clustering to find the k most dominant colors in
-// the given image.
-func DominantColors(k, maxIterations int, img image.Image) (map[color.Color]float64, error) {
+// FindPalette finds the k most dominant colors in the given image. It returns
+// a ColorPalette, after running the k-means algorithm up to maxIteration
+// times. See ClusterColors for the actual k-means implementation.
+func FindPalette(k, maxIterations int, img image.Image) (*ColorPalette, error) {
 	bounds := img.Bounds()
 	pixelCount := (bounds.Max.X - bounds.Min.X) * (bounds.Max.Y - bounds.Min.Y)
 	colors := make([]color.Color, pixelCount)
@@ -18,6 +21,5 @@ func DominantColors(k, maxIterations int, img image.Image) (map[color.Color]floa
 			i++
 		}
 	}
-	clusters, _, err := Cluster(k, maxIterations, colors)
-	return clusters, err
+	return ClusterColors(k, maxIterations, colors)
 }


### PR DESCRIPTION
This change seems better than passing `map[color.Color]float64` around everywhere, and adding extra return values to each function (e.g. number of iterations) whenever we need to expose more info from the inner workings of the clustering algorithm.

I also gave up on using "observations" in variable names throughout the k-means implementation in `kmeans.go`.  This was an attempt to keep the implementation tied directly to the standard algorithm description on which it was based, but I think it's unnecessarily distracting overall.

Lots of doc updates are in here, too.
